### PR TITLE
Altering schema definitions to incorporate optional fields

### DIFF
--- a/docs/composedb/examples/verifiable-credentials.mdx
+++ b/docs/composedb/examples/verifiable-credentials.mdx
@@ -327,12 +327,19 @@ interface VerifiableCredential
   context: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   type: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   credentialSchema: CredentialSchema!
+  credentialStatus: CredentialStatus
   issuanceDate: DateTime!
+  expirationDate: DateTime
 }
 
 type Issuer {
   id: String! @string(maxLength: 1000)
   name: String @string(maxLength: 1000)
+}
+
+type CredentialStatus {
+  id: String! @string(maxLength: 1000)
+  type: String! @string(maxLength: 1000)
 }
 
 type CredentialSchema {
@@ -349,11 +356,13 @@ interface VCEIP712Proof implements VerifiableCredential
   context: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   type: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   credentialSchema: CredentialSchema!
+  credentialStatus: CredentialStatus
   issuanceDate: DateTime!
+  expirationDate: DateTime
   proof: ProofEIP712!
 }
 
-## generalized JWT proof type
+## generalized JWT proof interface
 interface VCJWTProof implements VerifiableCredential
   @createModel(description: "A verifiable credential interface of type JWT")
 {
@@ -362,7 +371,9 @@ interface VCJWTProof implements VerifiableCredential
   context: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   type: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   credentialSchema: CredentialSchema!
+  credentialStatus: CredentialStatus
   issuanceDate: DateTime!
+  expirationDate: DateTime
   proof: ProofJWT!
 }
 
@@ -421,7 +432,9 @@ type VerifiableCredentialEIP712 implements VerifiableCredential & VCEIP712Proof
   context: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   type: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   credentialSchema: CredentialSchema!
+  credentialStatus: CredentialStatus
   issuanceDate: DateTime!
+  expirationDate: DateTime
   proof: ProofEIP712!
   credentialSubject: CredentialSubject! 
 }
@@ -436,7 +449,9 @@ type VerifiableCredentialJWT implements VerifiableCredential & VCJWTProof
   context: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   type: [String!]! @string(maxLength: 1000) @list(maxLength: 100)
   credentialSchema: CredentialSchema!
+  credentialStatus: CredentialStatus
   issuanceDate: DateTime!
+  expirationDate: DateTime
   proof: ProofJWT!
   credentialSubject: CredentialSubject! 
 }


### PR DESCRIPTION
Final adjustment to corresponding example app schema file was made to account for optional "credentialStatus" and "expirationDate" fields (according to W3C VC data model). This had to be additionally reflected in the docs guide