### PR TITLE
Add a CNAME file

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+developers.ceramic.network


### PR DESCRIPTION
A CNAME file is needed to deploy the docs using the custom domain instead of github.io domain