### PR TITLE
Update the composites guide 

### DIFF
--- a/docs/composedb/guides/data-modeling/composites.mdx
+++ b/docs/composedb/guides/data-modeling/composites.mdx
@@ -33,7 +33,7 @@ Let’s say you have a model written in a `my-schema.graphql` file. To convert t
   <TabItem value="cli">
 
 ```bash
-composedb composite:create my-schema.graphql --output=my-composite.json --did-private-key=your-private-key
+composedb composite:create my-schema.graphql --output=./__generated__/definition.json --did-private-key=your-private-key
 ```
 
   </TabItem>
@@ -65,16 +65,16 @@ const ceramic = new CeramicClient('http://localhost:7007')
 ceramic.did = did
 
 // Replace by the path to the source schema file
-const composite = await createComposite(ceramic, './source-schema.graphql')
+const composite = await createComposite(ceramic, './my-schema.graphql')
 
 // Replace by the path to the encoded composite file
-await writeEncodedComposite(composite, './my-composite.json')
+await writeEncodedComposite(composite, './__generated__/definition.json')
 ```
 
   </TabItem>
 </Tabs>
 
-This will create a file called `my-composite.json` which contains the composite in JSON. 
+This will create a file called `definition.json` which contains the composite definition in JSON.
 
 ### Deploying composites
 After creating the composite, deploy it to your local node: 
@@ -89,7 +89,7 @@ After creating the composite, deploy it to your local node:
   <TabItem value="cli">
 
 ```bash
-composedb composite:deploy my-composite.json --ceramic-url=http://localhost:7007 --did-private-key=your-private-key
+composedb composite:deploy ./__generated__/definition.json --ceramic-url=http://localhost:7007 --did-private-key=your-private-key
 ```
 
   </TabItem>
@@ -120,7 +120,7 @@ const ceramic = new CeramicClient('http://localhost:7007')
 ceramic.did = did
 
 // Replace by the path to the local encoded composite file
-const composite = await readEncodedComposite(ceramic, 'my-first-composite.json')
+const composite = await readEncodedComposite(ceramic, './__generated__/definition.json')
 
 // Notify the Ceramic node to index the models present in the composite
 await composite.startIndexingOn(ceramic)
@@ -138,9 +138,61 @@ This will also automatically add all models contained in the composite to the [M
 
 After deploying your composite, compile it so you can start perform [data interactions](../../guides/data-interactions/data-interactions.mdx) using the ComposeDB client.
 
+<Tabs
+  defaultValue="cli"
+  groupId="cli-or-js"
+  values={[
+    {label: 'CLI', value: 'cli'},
+    {label: 'JavaScript', value: 'js'},
+  ]}>
+  <TabItem value="cli">
+
 ```bash
-composedb composite:compile my-first-composite.json runtime-composite.json
+composedb composite:compile ./__generated__/definition.json ./__generated__/definition.js
 ```
+
+  </TabItem>
+  <TabItem value="js">
+
+```jsx
+import { CeramicClient } from '@ceramicnetwork/http-client'
+import { DID } from 'dids'
+import { Ed25519Provider } from 'key-did-provider-ed25519'
+import { getResolver } from 'key-did-resolver'
+import { fromString } from 'uint8arrays/from-string'
+
+import { writeEncodedCompositeRuntime } from '@composedb/devtools-node'
+
+// Hexadecimal-encoded private key for a DID having admin access to the target Ceramic node
+// Replace the example key here by your admin private key
+const privateKey = fromString('b0cb[...]515f', 'base16')
+
+const did = new DID({
+  resolver: getResolver(),
+  provider: new Ed25519Provider(privateKey),
+})
+await did.authenticate()
+
+// Replace by the URL of the Ceramic node you want to deploy the Models to
+const ceramic = new CeramicClient('http://localhost:7007')
+// An authenticated DID with admin access must be set on the Ceramic instance
+ceramic.did = did
+
+
+// Create a composite for runtime usage
+await writeEncodedCompositeRuntime(
+    ceramic,
+    './__generated__/definition.json',
+    './__generated__/definition.js'
+  );
+```
+
+  </TabItem>
+</Tabs>
+
+
+This will generate a composite definition `definition.js`, ready for the runtime use. Keep in mind that you 
+can compile the composite in `.json` and `.ts` formats as well. Check out the [API reference](https://composedb.js.org/) for more details.
 
 ## Advanced
 ---


### PR DESCRIPTION
[Linear Issue ](https://linear.app/3boxlabs/issue/DXC-268/missing-documentation-for-composite-definition)

**The problem:**

Our [composites guide](https://developers.ceramic.network/docs/composedb/guides/data-modeling/composites#basic-usage) has been missing a few steps (e.g. how to compile the composite and produce the .js runtime definition that is used in JavaScript configuration [example](https://developers.ceramic.network/docs/composedb/guides/composedb-client/javascript-client#configuration)). 

On top of that, the file names haven't been consistent with the names used in other guides as well as CLI vs JavaScript examples on the page.

**Proposed solution**
- Added the missing steps for compiling the composite
- Updated the file names so that they are consistent throughout the guide and are compatible with examples inlcluded in JavaScript Clinet config page.