### PR TITLE
Add success indicators for the getting started guide

### DIFF
--- a/docs/composedb/create-your-composite.mdx
+++ b/docs/composedb/create-your-composite.mdx
@@ -49,17 +49,23 @@ In this section we will show how to create a composite by downloading models fro
 You can fetch any existing model from the catalog by referencing the model’s unique ID. For example, for your basic social media app, use the existing model `SimpleProfile`. To fetch the model, to your working directory, take note of the model stream ID in the table above and run the following command:
 
 ```bash
-composedb composite:from-model kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9 --ceramic-url=http://localhost:7007 --output=my-first-composite-single.json
+composedb composite:from-model kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9 --ceramic-url=http://localhost:7007 --output=my-first-composite.json
 ```
 
-After running the command above, your will have the `SimpleProfile` model stored locally in a file called `my-first-composite-single.json`.
+You should see the following output in your terminal:
+
+```bash
+✔ Creating a composite from models... Composite was created and its encoded representation was saved in my-first-composite.json
+```
+
+This output means that you now have the `SimpleProfile` model stored locally in a file called `my-first-composite.json`.
 
 ### Using multiple models
 
 If your application needs multiple models, for example the `SimpleProfile` and `Post` models, you can. To fetch them, take note of the model stream IDs and provide them in a ComposeDB CLI command as follows:
 
 ```bash
-composedb composite:from-model kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9 kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96 --ceramic-url=http://localhost:7007 --output=my-first-composite.json
+composedb composite:from-model kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9 kjzl6hvfrbw6cb905umdi33gp1em1sp7b235z2h2orphj2p14by6llq9gwynsaf --ceramic-url=http://localhost:7007 --output=my-first-composite.json
 ```
 
 The output of this command will be a composite file named `my-first-composite.json`.
@@ -68,22 +74,27 @@ The output of this command will be a composite file named `my-first-composite.js
 ---
 ### Deploying the composite
 
-You will have to deploy the composite with fetched models to your local Ceramic node so that they can be used when building and running your applications. This can be achieved by using ComposeDB CLI and referencing the composite file of fetched models in your local environment as shown below. Note that you have to provide your did private key to deploy the model:
+You will have to deploy the composite with fetched models to your local Ceramic node so that they can be used when building and running your applications. This can be achieved by using ComposeDB CLI and referencing the composite file of fetched models in your local environment as shown below. Note that you have to provide [your did private key](./set-up-your-environment#generate-your-private-key) to deploy the model:
 
 ```bash
-composedb composite:deploy my-first-composite.json --ceramic-url=http://localhost:7007 --did-private-key=your_private_key
+composedb composite:deploy my-first-composite.json --ceramic-url=http://localhost:7007 --did-private-key=your-private-key
+```
+
+You should see the output similar to the one below:
+
+```bash
+ℹ Using DID did:key:z6MkoDgemAx51v8w692aZRLPdwP6UPKj3EgUhBTvbL7hCwLu
+✔ Deploying the composite... Done!
+["kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9"]
 ```
 
 Whenever composites are deployed, the models will be automatically indexed. This also means that these models are shared across the network (at the moment, only Clay testnet). If you check the output produced by the terminal that runs your Ceramic local node, you should see a similar output:
 
 ```bash
 IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9
-
-IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96
-
-IMPORTANT: Creating Compose DB Indexing table for model: kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9
-
-IMPORTANT: Creating Compose DB Indexing table for model: kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96
+IMPORTANT: Starting indexing for Model kjzl6hvfrbw6cb905umdi33gp1em1sp7b235z2h2orphj2p14by6llq9gwynsaf
+IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6c5ajfmes842lu09vjxu5956e3xq0xk12gp2jcf9s90cagt2god9
+IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6cb905umdi33gp1em1sp7b235z2h2orphj2p14by6llq9gwynsaf
 ```
 
 This means that the composite was deployed and the models were indexed on your local node successfully! 🎉
@@ -94,6 +105,13 @@ The last step left is compiling the composite. This is necessary to interact wit
 
 ```bash
 composedb composite:compile my-first-composite.json runtime-composite.json
+```
+
+You should see the following output in your terminal:
+
+```bash
+✔ Compiling the composite... Done!
+runtime-composite.json
 ```
 
 The output of this command will be a json file called `runtime-composite.json`

--- a/docs/composedb/interact-with-data.mdx
+++ b/docs/composedb/interact-with-data.mdx
@@ -11,10 +11,10 @@ Want to interact with data using JavaScript instead? See [Client setup](./guides
 
 ## Setup
 ### GraphQL Server
-To interact with data on the network, start a local GraphQL server by running the command below. Note that you have to provide the seed to your `did-private-key` here — it is also required for performing mutations, covered below.
+To interact with data on the network, start a local GraphQL server by running the command below. Note that you have to provide the [private key](./set-up-your-environment#generate-your-private-key) to your `did-private-key` here — it is also required for performing mutations, covered below.
 
 ```bash
-composedb graphql:server --ceramic-url=http://localhost:7007 --graphiql runtime-composite.json --did-private-key=your_private_key --port=5005
+composedb graphql:server --ceramic-url=http://localhost:7007 --graphiql runtime-composite.json --did-private-key=your-private-key --port=5005
 ```
 
 >✏️ ***Note:*** You can customize the port by configuring the `—-port` flag.
@@ -26,7 +26,8 @@ GraphQL server is listening on http://localhost:5005/graphql
 ```
 
 ### GraphQL Web UI
-In your browser, visit the URL that your local GraphQL server is listening on. You will see a simple UI that you can use to easily interact with your data:
+In your browser, visit the URL that your local GraphQL server is listening on. You will see a simple UI that you can use to easily interact with your data.
+This UI allows you to run queries by simply writing data queries inside of the editor you see below and pressing the "Play" button to see the results of the query:
 ![GraphQL Web UI](/img/graphiql.png)
   
 

--- a/docs/composedb/set-up-your-environment.mdx
+++ b/docs/composedb/set-up-your-environment.mdx
@@ -214,7 +214,7 @@ If you don’t already have them installed, you will need to install Node.js v20
 - [NodeJS v20](https://nodejs.org/en/)
 - [pnpm v10](https://pnpm.io/installation)
 
-Use this command to make sure you have the correct versions installed.
+Use the following command to check the versions you have installed.
 
 ```bash
 node -v
@@ -223,7 +223,7 @@ pnpm -v
 
 :::tip
 
-**Node.js** We've seen best results with Node.js v20. If you are using a different version (e.g. v16), you may run into issues. Please use `nvm` to install Node.js v20 for best results.
+**Node.js** We've seen best results with Node.js v20. If you are using a different version (e.g. v16), you may run into issues. Please use `nvm` to install Node.js v20.
 
 :::
 
@@ -402,11 +402,15 @@ yarn dlx @ceramicnetwork/cli daemon
   </TabItem>
 </Tabs>
 
-If you see the following output in your terminal, that means you have successfully started a local node and connected to Clay testnet 🚀
+You should see the following output in your terminal. This means you have successfully started a local node and connected to Clay testnet 🚀
 
 ```bash
 IMPORTANT: Ceramic API running on 0.0.0.0:7007
 ```
+
+Now, that you have installed everything successfully and are able to run the node, let's create a developer account. You can stop
+the node for now by using the keyboard combination `Control+C`. 
+
 
 ### Developer Account
 
@@ -414,11 +418,20 @@ IMPORTANT: Ceramic API running on 0.0.0.0:7007
 
 #### Generate your private key
 
-You will need a private key for authorizing ComposeDB CLI commands in the later stages of development. You can generate it using the command below. Save it for later use:
+You will need a private key for authorizing ComposeDB CLI commands in the later stages of development. You can generate it using the command below:
 
 ```bash
 composedb did:generate-private-key
 ```
+
+You should see the output similar to the one below. Keep in mind that the key generated for your will be unique and will different from the example shown below:
+
+```bash
+✔ Generating random private key... Done!
+5c7d2fa8ebc488f2fe008e5ed1db7f1f95c203434bbcbeb703491c405f6f31f0
+```
+
+Copy and save this key securely for later use.
 
 :::caution
 
@@ -428,17 +441,22 @@ composedb did:generate-private-key
 
 #### Generate your account
 
-Indexing is one of the key features of ComposeDB. In order to notify the Ceramic node which models have to be indexed, the ComposeDB tools have to interact with the restricted Admin API. Calling the API requires an authenticated Decentralized Identifier (DID) to be provided in the node configuration file. Create a DID by running the following command, using the private key generated previously:
+Indexing is one of the key features of ComposeDB. In order to notify the Ceramic node which models have to be indexed, the ComposeDB tools have to interact with the restricted Admin API. Calling the API requires an authenticated Decentralized Identifier (DID) to be provided in the node configuration file. Create a DID by running the following command, using the private key generated previously
+instead of the placeholder variable `your-private-key`:
 
 ```bash
 composedb did:from-private-key your-private-key
 ```
 
-The generated DID key will have the following format:
+You should see the output similar to the one below. Here again, the DID created for you will be unique and will differ
+from the one shown below:
 
-```json
-did:key:...
+```bash
+✔ Creating DID... Done!
+did:key:z6MkoDgemAx51v8w692aZRLPdwP6UPKj3EgUhBTvbL7hCwLu
 ```
+
+This key will be used to configure your node in the later steps of this guide.
 
 :::caution
 
@@ -455,19 +473,19 @@ The Ceramic node configuration file will be created inside of the automatically 
 cd ~/.ceramic
 ```
 
-Inside of this directory you should see the following files:
+Inside of this directory you should find the following files:
 
 - `daemon.config.json` - your Ceramic node configuration file
 - `statestore` - a local directory for [persisting the data](../protocol/js-ceramic/guides/ceramic-nodes/running-cloud#ceramic-state-store)
 
-Open the `daemon.config.json` file using your preferred code editor and provide the authenticated DID, generated in the [generate your account](#generate-your-account) step of this guide, in the `admin-dids` section of the file as shown below:
+Open the `daemon.config.json` file using your preferred code editor and provide the authenticated DID, generated in the [generate your account](#generate-your-account) step of this guide, in the `admin-dids` section of the file as shown in the example below:
 
 ```json
 {
   ...
   "http-api": {
     ...
-    "admin-dids": ["did:key:..."]
+    "admin-dids": ["did:key:z6MkoDgemAx51v8w692aZRLPdwP6UPKj3EgUhBTvbL7hCwLu"]
   },
   "indexing": {
     ...
@@ -476,8 +494,7 @@ Open the `daemon.config.json` file using your preferred code editor and provide 
 }
 ```
 
-Save this file and restart your Ceramic node for the changes to be applied. To do that, simply stop the process that is running the Ceramic node by hitting `ctrl+C` on your keyboard
-and spin up the node once again by following the steps in the [Confirmation](#confirmation) section of this guide.
+Save this file and start your Ceramic node again by following the steps in the [Confirmation](#confirmation) section of this guide.
 
 ### Confirmation
 


### PR DESCRIPTION
Addressing the feedback on the docs [here](https://linear.app/3boxlabs/issue/WS3-261/enhance-documentation-with-success-indicators-for-initial-setup-of). 

This PR adds success indicators for specific steps of the getting started guide - the outputs the developer should see as they follow the guide and how do they know they are executing the steps successfully.