### PR TITLE
Update mutations.mdx format

### DIFF
--- a/docs/composedb/guides/data-interactions/mutations.mdx
+++ b/docs/composedb/guides/data-interactions/mutations.mdx
@@ -65,13 +65,13 @@ Users will generate data as they interact with your app. Your app needs to perfo
 ```graphql
 # Create post
 
-mutation CreateNewPost($i: CreatePostInput!){
-  createPost(input: $i){
-		document{
-			id
-			title
-      text
-    }
+mutation CreateNewPost($i: CreatePostInput!) {
+  createPost(input: $i) {
+	document{
+		id
+		title
+	        text
+    	}
   }
 }
 
@@ -108,7 +108,7 @@ mutation UpdatePost($i: UpdatePostInput!) {
         document {
             id
             title
-						text
+            text
         }
     }
 }


### PR DESCRIPTION
Some indentations margin in this [page](https://developers.ceramic.network/docs/composedb/guides/data-interactions/mutations#update-data) look a little off, this PR aligns those fields.

Before:
![Screenshot 2024-02-07 at 9 27 47 AM](https://github.com/ceramicnetwork/docs-docusaurus/assets/8561085/14fe6daa-f3f8-4e46-af9b-f981973ce463)
![Screenshot 2024-02-07 at 9 30 55 AM](https://github.com/ceramicnetwork/docs-docusaurus/assets/8561085/3534ad47-ab49-4ee0-b07b-bd751505763e)
