### PR TITLE
Adding a query-all tag

### DIFF
--- a/src/components/sandbox/MutationSandbox.jsx
+++ b/src/components/sandbox/MutationSandbox.jsx
@@ -34,11 +34,19 @@ const fetcher = async (graphQLParams) => {
       category: "sandbox-query",
       action: "query-error",
     });
+    ReactGA.event({
+      category: "sandbox-query",
+      action: "query-all",
+    });
   }
   if (!data.data.__schema) {
     ReactGA.event({
       category: "sandbox-query",
       action: "mutation-success",
+    });
+    ReactGA.event({
+      category: "sandbox-query",
+      action: "query-all",
     });
     return data.data;
   }

--- a/src/components/sandbox/Sandbox.jsx
+++ b/src/components/sandbox/Sandbox.jsx
@@ -27,11 +27,19 @@ const fetcher = async (graphQLParams) => {
       category: "sandbox-query",
       action: "query-error",
     });
+    ReactGA.event({
+      category: "sandbox-query",
+      action: "query-all",
+    });
   }
   if (!data.data.__schema) {
     ReactGA.event({
       category: "sandbox-query",
       action: "query-success",
+    });
+    ReactGA.event({
+      category: "sandbox-query",
+      action: "query-all",
     });
     return data.data;
   }


### PR DESCRIPTION
Adding a query-all tag for all mutation and read queries, both successful and unsuccessful for easier tracking in google analytics