### PR TITLE
Add OrbisDB to the documentation

### DIFF
--- a/docs/introduction/composedb-overview.md
+++ b/docs/introduction/composedb-overview.md
@@ -1,4 +1,4 @@
-# ComposeDB Docs
+# ComposeDB
 ![Introduction](/img/intro-dataverse.png)
 
 ComposeDB is a composable graph database built on [Ceramic](https://ceramic.network), designed for Web3 applications. 

--- a/docs/introduction/orbisdb-overview.md
+++ b/docs/introduction/orbisdb-overview.md
@@ -1,0 +1,10 @@
+# OrbisDB
+
+OrbisDB is a simple and efficient gateway for storing and managing open data on Ceramic.
+
+OrbisDB provides a developer-friendly SQL interface to explore and query data on Ceramic as well as a user interface and plugin store to save development time on crypto-specific features – from data migration and token gating mechanisms to automated blockchain interactions.
+
+It is built on Ceramic's new Data Feed API which makes it fully compatible with [ComposeDB](./composedb-overview).
+
+
+Check out more details about [OrbisDB](../orbisdb/overview) and [OrbisDB SDK](../orbisdb/orbisdb-sdk).

--- a/docs/orbisdb/orbisdb-sdk.md
+++ b/docs/orbisdb/orbisdb-sdk.md
@@ -1,0 +1,8 @@
+# OrbisDB SDK
+
+OrbisDB comes with an [OrbisDB SDK](https://github.com/OrbisWeb3/db-sdk) which makes it easy to create, manage and query open data.
+
+OrbisDB SDK is a client-side complement to OrbisDB - a decentralized database built on top of Ceramic. It enables simple user authentication and provides necessary methods to manipulate the data.
+
+Head to the [OrbisDB SDK Github repository](https://github.com/OrbisWeb3/db-sdk) to start interacting with OrbisDB SDK.
+

--- a/docs/orbisdb/overview.md
+++ b/docs/orbisdb/overview.md
@@ -20,6 +20,6 @@ OrbisDB consists of two main components - core and plugins.
     - Divided into 4 categories (Create streams, Add metadata, Validate and Post process). More details about plugins underneath.
 
 
-Head to [OrbisDB Github repository](https://github.com/OrbisWeb3/orbisdb) to start building using OrbisDB.
+Start building using [OrbisDB](https://useorbis.com/).
 
 

--- a/docs/orbisdb/overview.md
+++ b/docs/orbisdb/overview.md
@@ -1,0 +1,25 @@
+# OrbisDB
+
+[OrbisDB](https://github.com/OrbisWeb3/orbisdb) is a developer-friendly interface to explore data with the ease of SQL and a plugin store to save development time on processes like data migration and gating mechanisms all the way to automated blockchain interactions.
+
+OrbisDB is powered by Ceramic's Data Feed API which means that in order to interact with OrbisDB, you have to run a [Ceramic Node](../protocol/js-ceramic/nodes/running-a-node#install-and-run-the-ceramic-cli).
+
+OrbisDB comes with a easy-to-use [OrbisDB SDK](./orbisdb-sdk) for interacting with data. 
+
+
+## Key components
+
+OrbisDB consists of two main components - core and plugins.
+
+- Core:
+    - Dedicated to read/write operation of the indexing service
+    - Listens to stream changes of specific models being used by developers and indexes the content in a Postgres database.
+
+- Plugins:
+    - Optional and designed to perform operations beyond the core’s scope.
+    - Divided into 4 categories (Create streams, Add metadata, Validate and Post process). More details about plugins underneath.
+
+
+Head to [OrbisDB Github repository](https://github.com/OrbisWeb3/orbisdb) to start building using OrbisDB.
+
+

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -430,6 +430,10 @@ const config: Config = {
 
           items: [
             {
+              to: "docs/orbisdb/overview",
+              label: "OrbisDB"
+            },
+            {
               to: "docs/composedb/getting-started",
               label: "ComposeDB"
             },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         { type: "doc", id: "introduction/protocol-overview", label: "Ceramic Protocol" },
+        { type: "doc", id: "introduction/orbisdb-overview", label: "OrbisDB" },
         { type: "doc", id: "introduction/composedb-overview", label: "ComposeDB" },
         { type: "doc", id: "introduction/did-overview", label: "Decentralized Identifiers" }
       ]

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -462,7 +462,21 @@ const sidebars: SidebarsConfig = {
       id: "ecosystem/community",
       label: "Overview"
     }
-  ]
+  ],
+  orbisdb: [
+    {
+      type: "doc",
+      id: "orbisdb/overview",
+      label: "OrbisDB Overview"
+    },
+    {
+      type: "doc",
+      id: "orbisdb/orbisdb-sdk",
+      label: "OrbisDB SDK"
+    },
+    
+  ],
+
 
   // But you can create a sidebar manually
   /*


### PR DESCRIPTION
**Merge only after the OrbisDB launch**

This PR adds the following changes to the documentation:
- Add OrbisDB to the top navbar of the docs.
- Add OrbisDB to the Introduction section of the documentation.