### PR TITLE
Feature/ws2 3149 put all the docs to docusaurus repo from notion

### DIFF
--- a/docs/composedb/guides/data-modeling/relations.mdx
+++ b/docs/composedb/guides/data-modeling/relations.mdx
@@ -74,9 +74,9 @@ Where:
 
 Model to model relations enable you to link data to and query data from another piece of data. These relations can be uni-directional (e.g. query a post from a comment) or bi-directional (e.g. query a post from a comment and query all comments from a post).
 
-### Example: Post with comments
+### Example: Post with comments and likes
 
-Here’s a model that allows many comments to be made on a single post. It supports unlimited comments per user, and bi-directional queries from any comment to the original post and from the original post to all of its comments.
+Here’s a model that allows many comments from the same or different account to be made on a single post. It supports unlimited comments per user, and bi-directional queries from any comment or like to the original post and from the original post to all of its comments and likes. The model schema also creates a relation between posts and likes enabling a single like per post by an account, meaning a single account will only be able to like the post once
 
 ```graphql
 # Load post model (using streamID)
@@ -86,13 +86,21 @@ type Post @loadModel(id: "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344z
 }
 
 # New comment model
-# Set relationship to original post
+# Set reference to original post
 # Enable querying comment to get original post
 
 type Comment @createModel(accountRelation: LIST, description: "A comment on a Post") {
   postID: StreamID! @documentReference(model: "Post")
   post: Post! @relationDocument(property: "postID")
   text: String! @string(maxLength: 500)
+}
+
+# New like model
+# Set relationship to original post
+# Enable querying comment to get original post
+type Like @createModel(description: "A like on a post", accountRelation: SET, accountRelationFields: ["postID"]) {
+  postID: StreamID! @documentReference(model: "Post")
+  post: Post! @relationDocument(property: "postID")
 }
 ```
 
@@ -106,12 +114,13 @@ type Comment @loadModel(id: "kjzl6hvfrbw6c9oo2ync09y6z5c9mas9u49lfzcowepuzxmcn3p
 }
 
 # Load post model
-# Extend post model with comments
-# Set relationships to all comments
-# Enable querying post to get all comments
+# Extend post model with comments and likes
+# Set relationships to all comments and likes
+# Enable querying post to get all comments and likes
 
 type Post @loadModel(id: "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96") {
   comments: [Comment] @relationFrom(model: "Comment", property: "postID")
+  likes: [Like] @relationFrom(model: "Like", property: "postID")
 }
 ```
 
@@ -122,6 +131,7 @@ Where:
 - `post` allows accessing the original post from the comment, using `@relationDocument`
 - `text` defines a string for the comment
 - `comments` defines the relationships from a post to a collection of comments, using `@relationFrom`; requires specifying the model relation (`Comment`) and the specific property that stores the relation (`postID`)
+- `likes` defines the relationships from a post to a collection of comments, using `@relationFrom`; requires specifying the model relation (`Like`) and the specific property that stores the relation (`postID`)
 
 ### Using interfaces
 

--- a/docs/composedb/guides/data-modeling/relations.mdx
+++ b/docs/composedb/guides/data-modeling/relations.mdx
@@ -72,7 +72,9 @@ Where:
 
 ---
 
-Model to model relations enable you to link data to and query data from another piece of data. These relations can be uni-directional (e.g. query a post from a comment) or bi-directional (e.g. query a post from a comment and query all comments from a post).
+Model to model relations enable you to link data to and query data from another piece of data. These relations can be uni-directional (e.g. query a post from a comment) or bi-directional (e.g. query a post from a comment and query all comments from a post). 
+
+There is type of model-to-model relation that includes the user as part of the relationship. This is achieved by using the `SET` account relation type, which allows users to enforce a constraint where each user account (or DID) can create only one instance of a model for a specific record of another model.
 
 ### Example: Post with comments and likes
 

--- a/docs/composedb/guides/data-modeling/schemas.mdx
+++ b/docs/composedb/guides/data-modeling/schemas.mdx
@@ -135,7 +135,7 @@ Where:
 - `@string` adds validation rules to values that are strings, e.g. minimum and maximum length
 - `@int` adds validation rules to values that are integers, e.g. minimum and maximum values
 - `@list` adds validation rules to an array, e.g. maximum length
-- `@immutable` ensures that after a field value is set it won't be updated, like a read-only value
+- `@immutable` ensures that after a field value is set it won't be updated
 
 #### Directives for creating indices
 

--- a/docs/composedb/guides/data-modeling/schemas.mdx
+++ b/docs/composedb/guides/data-modeling/schemas.mdx
@@ -125,7 +125,7 @@ type EducationModule {
 type Learner {
   first_name: String! @string(minLength: 10, maxLength: 30)
   last_name: String! @string(maxLength: 30)
-  username: String! @string(maxLength: 32)
+  username: String! @string(maxLength: 32) @immutable
 }
 ```
 
@@ -135,6 +135,7 @@ Where:
 - `@string` adds validation rules to values that are strings, e.g. minimum and maximum length
 - `@int` adds validation rules to values that are integers, e.g. minimum and maximum values
 - `@list` adds validation rules to an array, e.g. maximum length
+- `@immutable` ensures that after a field value is set it won't be updated, like a read-only value
 
 #### Directives for creating indices
 

--- a/docs/composedb/guides/data-modeling/schemas.mdx
+++ b/docs/composedb/guides/data-modeling/schemas.mdx
@@ -107,7 +107,7 @@ type Post implements TextContent @createModel(description: "Post model") {
 
 ### Directives
 
-ComposeDB comes with [a list of different directives](https://composedb.js.org/docs/0.5.x/api/sdl/directives) that can be used to create or load data models, define type validation rules, and create indices
+ComposeDB comes with [a list of different directives](https://composedb.js.org/docs/0.7.x/api/sdl/directives) that can be used to create or load data models, define type validation rules, and create indices
 for specific fields which enables them to be used for document filtering and sorting.
 
 #### Type validation directives

--- a/docs/composedb/interact-with-data.mdx
+++ b/docs/composedb/interact-with-data.mdx
@@ -109,7 +109,7 @@ query{
   
 
 ## Mutations
-There are two types of mutations you can perform on ComposeDB data: creating and updating records.
+There are three types of mutations you can perform on ComposeDB data: creating, and updating records, or change wether the records is indexed or not.
   
 ### Creating records
 Let’s say, you would like to create a post and add it to the graph. To do that, you will have to run a mutation as shown below and pass the actual text as a variable:
@@ -227,6 +227,50 @@ This mutation will update the record with ID `kjzl6kcym7w8y9xlffqruh3v7ou1vn11t8
         "id": "kjzl6kcym7w8y9xlffqruh3v7ou1vn11t8203i6te2i3pliizt65ad3vdh5nl4l",
         "text": "My best post!"
       }
+    }
+  }
+}
+```
+
+### Remove/Restore record from index
+If instead of updating the created post record we want to stop indexing said record we would need to  use the `enableIndexingPost`
+mutation with the `shouldIndex` option set to `false`, or if we want to index an un-indexed record we can call the `enableIndexingPost`
+mutation with the `shouldIndex` option set to `true`, and the post ID as variable.
+  
+
+**Query:**
+
+```graphql
+mutation EnableIndexingPost($input: EnableIndexingPostInput!) {
+      enableIndexingPost(input: $input) {
+          document {
+            id
+          }
+        }
+      }
+```
+
+  
+
+**Variables:**
+
+```json
+{
+  "i": {
+    "id": "kjzl6kcym7w8y9xlffqruh3v7ou1vn11t8203i6te2i3pliizt65ad3vdh5nl4l",
+    "shouldIndex": false
+  }
+}
+```
+
+This mutation will un-index the record with ID `kjzl6kcym7w8y9xlffqruh3v7ou1vn11t8203i6te2i3pliizt65ad3vdh5nl4l`.
+
+**Response:**
+```json
+{
+  "data": {
+    "enableIndexingPost": {
+      "document": null
     }
   }
 }


### PR DESCRIPTION
The majority of documentation will be in the composedb side, consider this PR as part 1 of making public documentation about:
- set account relation
- immutable fields
- shouldIndex functionality

The part 2 PR is going to be inside the js-composedb repository including more information about these topics.