### PR TITLE
Update the model IDs in guides

### DIFF
--- a/docs/composedb/create-your-composite.mdx
+++ b/docs/composedb/create-your-composite.mdx
@@ -49,7 +49,7 @@ In this section we will show how to create a composite by downloading models fro
 You can fetch any existing model from the catalog by referencing the model’s unique ID. For example, for your basic social media app, use the existing model `SimpleProfile`. To fetch the model, to your working directory, take note of the model stream ID in the table above and run the following command:
 
 ```bash
-composedb composite:from-model kjzl6hvfrbw6c5bf2jmwo9scp1ctkqvs5nru1jfjb1dgqqnf90sycptlztjdfep --ceramic-url=http://localhost:7007 --output=my-first-composite.json
+composedb composite:from-model kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65 --ceramic-url=http://localhost:7007 --output=my-first-composite.json
 ```
 
 You should see the following output in your terminal:
@@ -65,7 +65,7 @@ This output means that you now have the `SimpleProfile` model stored locally in 
 If your application needs multiple models, for example the `SimpleProfile` and `Post` models, you can. To fetch them, take note of the model stream IDs and provide them in a ComposeDB CLI command as follows:
 
 ```bash
-composedb composite:from-model kjzl6hvfrbw6c5bf2jmwo9scp1ctkqvs5nru1jfjb1dgqqnf90sycptlztjdfep kjzl6hvfrbw6c7gkodzmqq5s031yfo5xdllvcr1z0tumwl7kpml4gfe5gbwh2bg --ceramic-url=http://localhost:7007 --output=my-first-composite.json
+composedb composite:from-model kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65 kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy --ceramic-url=http://localhost:7007 --output=my-first-composite.json
 ```
 
 The output of this command will be a composite file named `my-first-composite.json`.
@@ -85,16 +85,16 @@ You should see the output similar to the one below:
 ```bash
 ℹ Using DID did:key:z6MkoDgemAx51v8w692aZRLPdwP6UPKj3EgUhBTvbL7hCwLu
 ✔ Deploying the composite... Done!
-["kjzl6hvfrbw6c5bf2jmwo9scp1ctkqvs5nru1jfjb1dgqqnf90sycptlztjdfep"]
+["kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65"]
 ```
 
 Whenever composites are deployed, the models will be automatically indexed. This also means that these models are shared across the network (at the moment, only Clay testnet). If you check the output produced by the terminal that runs your Ceramic local node, you should see a similar output:
 
 ```bash
-IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c5bf2jmwo9scp1ctkqvs5nru1jfjb1dgqqnf90sycptlztjdfep
-IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c7gkodzmqq5s031yfo5xdllvcr1z0tumwl7kpml4gfe5gbwh2bg
-IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6c5bf2jmwo9scp1ctkqvs5nru1jfjb1dgqqnf90sycptlztjdfep
-IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6c7gkodzmqq5s031yfo5xdllvcr1z0tumwl7kpml4gfe5gbwh2bg
+IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65
+IMPORTANT: Starting indexing for Model kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy
+IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65
+IMPORTANT: Creating ComposeDB Indexing table for model: kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy
 ```
 
 This means that the composite was deployed and the models were indexed on your local node successfully! 🎉

--- a/docs/composedb/guides/data-modeling/composites.mdx
+++ b/docs/composedb/guides/data-modeling/composites.mdx
@@ -214,7 +214,7 @@ As an example, let’s reuse the `merged-composite.json` file from the previous 
   <TabItem value="cli">
 
 ```bash
-composedb composite:extract-model merged-composite.json kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc --output=new-composite.json
+composedb composite:extract-model merged-composite.json kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65 --output=new-composite.json
 ```
 
   </TabItem>
@@ -228,7 +228,7 @@ import { readEncodedComposite, writeEncodedComposite } from '@composedb/devtools
 const ceramic = new CeramicClient('http://localhost:7007')
 const sourceComposite = await readEncodedComposite(ceramic, 'merged-composite.json')
 
-const mergedComposite = sourceComposite.copy(['kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc'])
+const mergedComposite = sourceComposite.copy(['kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65'])
 await writeEncodedComposite(mergedComposite, 'new-composite.json')
 ```
   </TabItem>
@@ -252,8 +252,8 @@ To manually set aliases for your models, add the following section to your compo
 
 ```jsx
 "aliases":{
-      "kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc":"SimpleProfile",
-      "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96":"Post"
+      "kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65":"SimpleProfile",
+      "kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy":"Post"
    }
 ```
 
@@ -268,8 +268,8 @@ const ceramic = new CeramicClient('http://localhost:7007')
 const sourceComposite = await readEncodedComposite(ceramic, 'merged-composite.json')
 
 const newComposite = sourceComposite.setAliases({
-  'kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc': 'SimpleProfile',
-  'kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96': 'Post',
+  'kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65': 'SimpleProfile',
+  'kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy': 'Post',
 })
 await writeEncodedComposite(newComposite, 'new-composite.json')
 ```
@@ -278,8 +278,8 @@ This script will create a file named `new-composite.json` including model aliase
 
 ```jsx
 "aliases":{
-      "kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc":"SimpleProfile",
-      "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96":"Post"
+      "kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65":"SimpleProfile",
+      "kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy":"Post"
    }
 ```
 

--- a/docs/composedb/guides/data-modeling/model-catalog.mdx
+++ b/docs/composedb/guides/data-modeling/model-catalog.mdx
@@ -46,7 +46,7 @@ You will see a table where each model has the following metadata properties:
 Fetch a single model from the catalog and convert it into a composite, using its model ID:
 
 ```sh
-composedb composite:from-model kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc --output=my-composite.json
+composedb composite:from-model kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65 --output=my-composite.json
 ```
 
 ### Using multiple models

--- a/docs/composedb/guides/data-modeling/relations.mdx
+++ b/docs/composedb/guides/data-modeling/relations.mdx
@@ -83,7 +83,7 @@ Here’s a model that allows many comments from the same or different account to
 ```graphql
 # Load post model (using streamID)
 
-type Post @loadModel(id: "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96") {
+type Post @loadModel(id: "kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy") {
   id: ID!
 }
 
@@ -120,7 +120,7 @@ type Comment @loadModel(id: "kjzl6hvfrbw6c9oo2ync09y6z5c9mas9u49lfzcowepuzxmcn3p
 # Set relationships to all comments and likes
 # Enable querying post to get all comments and likes
 
-type Post @loadModel(id: "kjzl6hvfrbw6c99mdfpjx1z3fue7sesgua6gsl1vu97229lq56344zu9bawnf96") {
+type Post @loadModel(id: "kjzl6hvfrbw6c822s0cj1ug59spj648ml8a6mbqaz91wx8zx3mlwi76tfh3u1dy") {
   comments: [Comment] @relationFrom(model: "Comment", property: "postID")
   likes: [Like] @relationFrom(model: "Like", property: "postID")
 }

--- a/docs/composedb/set-up-your-environment.mdx
+++ b/docs/composedb/set-up-your-environment.mdx
@@ -43,9 +43,9 @@ ceramic-one daemon
 ```
 
 :::note
-By default, the command above will spin off a node which connects to a `clay-testnet` network. You can change this behaviour by providing a `--network` flag and specifying a network of your choice. For example:
+By default, the command above will spin off a node which connects to a `testnet-clay` network. You can change this behaviour by providing a `--network` flag and specifying a network of your choice. For example:
 
-```ceramic-one daemon --network clay-testnet```
+```ceramic-one daemon --network testnet-clay```
 :::
 
 


### PR DESCRIPTION
Update the model IDs used in ComposeDB guides to the ones that are compatible with ceramic-one.