### PR TITLE
docs: fix invalid links

### DIFF
--- a/docs/composedb/create-ceramic-app.mdx
+++ b/docs/composedb/create-ceramic-app.mdx
@@ -60,4 +60,4 @@ bunx create-ceramic-app
 
 This command will create a new directory with a basic ComposeDB application (a social app). It will clone the app from [repository](https://github.com/ceramicstudio/ComposeDbExampleApp.git), install all dependencies, launch a local Ceramic node, a local GraphQL server and start the app.
 
-Once you have an opportunity to play with an example app and see how it works, you can start building your own app. For that, you will probably want to have more control over your environment and the code. You can find more information on how to set up your environment in the [Set up your environment](./set-up-your-environment) section.
+Once you have an opportunity to play with an example app and see how it works, you can start building your own app. For that, you will probably want to have more control over your environment and the code. You can find more information on how to set up your environment in the [Set up your environment](./set-up-your-environment.mdx) section.

--- a/docs/composedb/examples/index.mdx
+++ b/docs/composedb/examples/index.mdx
@@ -1,3 +1,3 @@
 # Tutorials and Examples
 
-If you have built an example app from the [**Set up your environment**](./set-up-your-environment) section and now you're looking for more, check out the extensive list of [**Starter Applications and Tutorials**](./examples/tutorials-and-examples) or go deep with the [**Verifiable Credentials**](./examples/verifiable-credentials) guide.
+If you have built an example app from the [**Set up your environment**](/docs/composedb/set-up-your-environment.mdx) section and now you're looking for more, check out the extensive list of [**Starter Applications and Tutorials**](./tutorials-and-examples.mdx) or go deep with the [**Verifiable Credentials**](./verifiable-credentials.mdx) guide.

--- a/docs/composedb/getting-started.mdx
+++ b/docs/composedb/getting-started.mdx
@@ -30,12 +30,12 @@ ComposeDB on Ceramic stores and manages data while delivering fast queries and a
 
 ## How to Get Started
 
-- [**See how it works**](./sandbox) - Explore the ComposeDB Sandbox, a web-based environment to interact with ComposeDB. Run some queries, interact with data, learn about the core concepts.
-- [**Create your first Ceramic app**](./create-ceramic-app) - As easy as running `npx create-ceramic-app`, run your first local Ceramic app and start diving into code.
-- [**Set up your environment**](./set-up-your-environment) - Learn how to set up your development environment to start building with ComposeDB. Experience the real Ceramic network, either on the testnet or mainnet.
-- [**Create your composite**](./create-your-composite) - Learn how to create your first composite, a reusable data model that can be used across different applications.
-- [**Interact with data**](./interact-with-data) - Learn how to interact with data in ComposeDB, from creating, reading, updating, and deleting data to running complex queries.
-- [**Core ComposeDB concepts**](./core-concepts) - Learn about the core concepts of ComposeDB, such as composites, schemas, and queries.
+- [**See how it works**](./sandbox.mdx) - Explore the ComposeDB Sandbox, a web-based environment to interact with ComposeDB. Run some queries, interact with data, learn about the core concepts.
+- [**Create your first Ceramic app**](./create-ceramic-app.mdx) - As easy as running `npx create-ceramic-app`, run your first local Ceramic app and start diving into code.
+- [**Set up your environment**](./set-up-your-environment.mdx) - Learn how to set up your development environment to start building with ComposeDB. Experience the real Ceramic network, either on the testnet or mainnet.
+- [**Create your composite**](./create-your-composite.mdx) - Learn how to create your first composite, a reusable data model that can be used across different applications.
+- [**Interact with data**](./interact-with-data.mdx) - Learn how to interact with data in ComposeDB, from creating, reading, updating, and deleting data to running complex queries.
+- [**Core ComposeDB concepts**](./core-concepts.mdx) - Learn about the core concepts of ComposeDB, such as composites, schemas, and queries.
 
 ## Join Ceramic Community 💜
 

--- a/docs/composedb/introduction.mdx
+++ b/docs/composedb/introduction.mdx
@@ -35,17 +35,17 @@ Thank you for being a ComposeDB pioneer and understanding that great Web3 protoc
 
 
 
-### [Get Started →](./getting-started) 
+### [Get Started →](./getting-started.mdx) 
 Build a Hello World application and interact from the CLI.
 
-### [ComposeDB Sandbox →](/docs/composedb/sandbox) 
+### [ComposeDB Sandbox →](/docs/composedb/sandbox.mdx) 
 Test example queries to ComposeDB directly in your browser.
 
-### [Development Guides →](./getting-started)
+### [Development Guides →](./getting-started.mdx)
 Learn about data modeling, application set up, and data interactions.
 <!-- Server Config-->
 
-### [Core concepts →](./core-concepts)
+### [Core concepts →](./core-concepts.mdx)
 Dive deeper into the ComposeDB protocol and its components.
   
 ### [Community →](../ecosystem/community.mdx)

--- a/docs/composedb/set-up-your-environment.mdx
+++ b/docs/composedb/set-up-your-environment.mdx
@@ -754,7 +754,7 @@ In this Quickstart guide, you have learned how to get started with ComposeDB. Yo
 
 <!-- Link to page explaining how play with the example app -->
 
-- [**Create your composite**](./create-your-composite) - Learn how to create your first composite, a reusable data model that can be used across different applications.
-- [**Interact with data**](./interact-with-data) - Learn how to interact with data in ComposeDB, from creating, reading, updating, and deleting data to running complex queries.
-- [**Core ComposeDB concepts**](./core-concepts) - Learn about the core concepts of ComposeDB, such as composites, schemas, and queries.
-- [**Running in the cloud**](./guides/composedb-server/running-in-the-cloud) - Ready to upgrade from a local node to production? Learn how to deploy your app.
+- [**Create your composite**](./create-your-composite.mdx) - Learn how to create your first composite, a reusable data model that can be used across different applications.
+- [**Interact with data**](./interact-with-data.mdx) - Learn how to interact with data in ComposeDB, from creating, reading, updating, and deleting data to running complex queries.
+- [**Core ComposeDB concepts**](./core-concepts.mdx) - Learn about the core concepts of ComposeDB, such as composites, schemas, and queries.
+- [**Running in the cloud**](./guides/composedb-server/running-in-the-cloud.mdx) - Ready to upgrade from a local node to production? Learn how to deploy your app.

--- a/docs/ecosystem/community.mdx
+++ b/docs/ecosystem/community.mdx
@@ -25,7 +25,7 @@ If you’re interested in a grant feel free to reach out in the #bounties channe
 - **Marketplace GUI:** Wouldn’t it be great if developers could access the composite marketplace with an app UI instead of a terminal?
 - **Sample Apps & Models:** Inspire other developers by building sample apps & data models, like reputation credentials, social apps, or DAO tools.
 - **Easy Node Setup:** Make it easy to deploy ComposeDB on a node - we wrote a [proof of concept](https://github.com/ceramicstudio/ceramic-infra-poc) you can build on. Bonus: Terraform templates for cloud providers like AWS, GCP, and DigitalOcean.
-- **Config Script:** We’d love to make [Set up your environment](../composedb/set-up-your-environment) even easier. Want to create a lightning fast script?
+- **Config Script:** We’d love to make [Set up your environment](../composedb/set-up-your-environment.mdx) even easier. Want to create a lightning fast script?
 
 ### **Open source contributions**
 Contribute to the [ComposeDB repository](https://github.com/ceramicstudio/js-composedb): here are some packages to get started

--- a/docs/introduction/composedb-overview.md
+++ b/docs/introduction/composedb-overview.md
@@ -35,18 +35,18 @@ Thank you for being a ComposeDB pioneer and understanding that great Web3 protoc
 ---
 
 
-### [Get Started →](../composedb/getting-started) 
+### [Get Started →](../composedb/getting-started.mdx) 
 Build a Hello World application and interact from the CLI.
 
-### [ComposeDB Sandbox →](/docs/composedb/sandbox) 
+### [ComposeDB Sandbox →](/docs/composedb/sandbox.mdx) 
 Test example queries to ComposeDB directly in your browser.
 
-### [Development Guides →](../composedb/guides)
+### [Development Guides →](../composedb/guides/index.mdx)
 Learn about data modeling, application set up, and data interactions.
 <!-- Server Config-->
 
-### [Core concepts →](../composedb/core-concepts)
+### [Core concepts →](../composedb/core-concepts.mdx)
 Dive deeper into the ComposeDB protocol and its components.
   
-### [Community →](../ecosystem/community)
+### [Community →](../ecosystem/community.mdx)
 Connect with the ComposeDB developer community.

--- a/docs/introduction/protocol-overview.md
+++ b/docs/introduction/protocol-overview.md
@@ -10,7 +10,7 @@ Ceramic is a decentralized event streaming protocol that enables developers to b
 
 The Ceramic protocol consists of the following components:
 
-- [**Streams →**](../protocol/js-ceramic/streams/streams-index)
+- [**Streams →**](../protocol/js-ceramic/streams/streams-index.md)
 - [**Accounts →**](../protocol/js-ceramic/accounts/accounts-index.md)
 - [**Networking →**](../protocol/js-ceramic/networking/networking-index.md)
 - [**Ceramic API →**](../protocol/js-ceramic/api.md)
@@ -23,22 +23,22 @@ The Ceramic protocol consists of the following components:
 
 | Section | State |
 | --- | --- |
-| [1. Streams](../protocol/js-ceramic/streams/streams-index) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/streams/streams-index)** |
-| [1.1. Event Log](../protocol/js-ceramic/streams/event-log) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/event-log)** |
-| [1.2. URI Scheme](../protocol/js-ceramic/streams/uri-scheme) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/uri-scheme)** |
-| [1.3. Consensus](../protocol/js-ceramic/streams/consensus) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/streams/consensus)** |
-| [1.4. Lifecycle](../protocol/js-ceramic/streams/lifecycle) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/lifecycle)** |
-| [2. Accounts](../protocol/js-ceramic/accounts/accounts-index) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/accounts-index)** |
-| [2.1. Decentralized Identifiers](../protocol/js-ceramic/accounts/decentralized-identifiers) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/decentralized-identifiers)** |
-| [2.2. Authorizations](../protocol/js-ceramic/accounts/authorizations) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/accounts/authorizations)** |
-| [2.3. Object-Capabilities](../protocol/js-ceramic/accounts/object-capabilities) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/object-capabilities)** |
-| [3. Networking](../protocol/js-ceramic/networking/networking-index) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/networking/networking-index)** |
-| [3.1. Tip Gossip](../protocol/js-ceramic/networking/tip-gossip) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/tip-gossip)** |
-| [3.2. Tip Queries](../protocol/js-ceramic/networking/tip-queries) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/tip-queries)** |
-| [3.3. Event Fetching](../protocol/js-ceramic/networking/event-fetching) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/event-fetching)** |
-| [3.4. Network Identifiers](../protocol/js-ceramic/networking/networks) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/networks)** |
-| [4. API](../protocol/js-ceramic/api) | **[<span styles="color:rgba(212, 76, 71, 1)">Missing</span>](../protocol/js-ceramic/api)** |
-| [5. Nodes](../protocol/js-ceramic/nodes/overview) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/nodes/overview)** |
+| [1. Streams](../protocol/js-ceramic/streams/streams-index.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/streams/streams-index.md)** |
+| [1.1. Event Log](../protocol/js-ceramic/streams/event-log.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/event-log.md)** |
+| [1.2. URI Scheme](../protocol/js-ceramic/streams/uri-scheme.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/uri-scheme.md)** |
+| [1.3. Consensus](../protocol/js-ceramic/streams/consensus.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/streams/consensus.md)** |
+| [1.4. Lifecycle](../protocol/js-ceramic/streams/lifecycle.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/streams/lifecycle.md)** |
+| [2. Accounts](../protocol/js-ceramic/accounts/accounts-index.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/accounts-index.md)** |
+| [2.1. Decentralized Identifiers](../protocol/js-ceramic/accounts/decentralized-identifiers.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/decentralized-identifiers.md)** |
+| [2.2. Authorizations](../protocol/js-ceramic/accounts/authorizations.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/accounts/authorizations.md)** |
+| [2.3. Object-Capabilities](../protocol/js-ceramic/accounts/object-capabilities.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/accounts/object-capabilities.md)** |
+| [3. Networking](../protocol/js-ceramic/networking/networking-index.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/networking/networking-index.md)** |
+| [3.1. Tip Gossip](../protocol/js-ceramic/networking/tip-gossip.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/tip-gossip.md)** |
+| [3.2. Tip Queries](../protocol/js-ceramic/networking/tip-queries.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/tip-queries.md)** |
+| [3.3. Event Fetching](../protocol/js-ceramic/networking/event-fetching.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/event-fetching.md)** |
+| [3.4. Network Identifiers](../protocol/js-ceramic/networking/networks.md) | **[<span styles="color:rgba(68, 131, 97, 1)">Reliable</span>](../protocol/js-ceramic/networking/networks.md)** |
+| [4. API](../protocol/js-ceramic/api.md) | **[<span styles="color:rgba(212, 76, 71, 1)">Missing</span>](../protocol/js-ceramic/api.md)** |
+| [5. Nodes](../protocol/js-ceramic/nodes/overview.md) | **[<span styles="color:rgba(203, 145, 47, 1)">Draft/WIP</span>](../protocol/js-ceramic/nodes/overview.md)** |
 
 #### **Legend**
 

--- a/docs/wheel/wheel-reference.mdx
+++ b/docs/wheel/wheel-reference.mdx
@@ -30,7 +30,7 @@ the following options:
   housekeeping reasons.
 - `Mainnet` - for projects in the production stage. This option will require you to do more advanced configurations for
   your working environment. Generally, this option is only recommended for generating a production configuration file to be
-  used with a production deployment like [Kubernetes](../composedb/guides/composedb-server/running-in-the-cloud).
+  used with a production deployment like [Kubernetes](../composedb/guides/composedb-server/running-in-the-cloud.mdx).
 
 ### Project Name
 
@@ -79,7 +79,7 @@ use the default suggestion (recommended in most of the cases) or specify a custo
 
 ### CAS Authentication
 
-In order to control the nodes connected to CAS (Ceramic Anchor Service), you will have to [configure the authentication](../composedb/guides/composedb-server/access-mainnet).
+In order to control the nodes connected to CAS (Ceramic Anchor Service), you will have to [configure the authentication](../composedb/guides/composedb-server/access-mainnet.mdx).
 This will allow you to set or revoke DIDs for your nodes. You can choose from the following options:
 
 - Email Based Authentication - an email authentication method. You will be asked to provide an email that will be used to provide you with an OTP code (a passcode) needed for the authentication.


### PR DESCRIPTION
Mostly due to missing extensions of ‘.md’, ‘.mdx’, etc. the link was not set correctly. Hope this fix helps.