### PR TITLE
Update outdated pieces

### DIFF
--- a/docs/composedb/create-ceramic-app.mdx
+++ b/docs/composedb/create-ceramic-app.mdx
@@ -11,6 +11,35 @@ Get up and running quickly with a basic ComposeDB application with one command.
 - **Node.js v20** - If you are using a different version, please use `nvm` to install Node.js v20 for best results.
 - **npm v10** - Installed automatically with NodeJS v20
 
+You will also need to run a ceramic-one node in the background which provides Ceramic 
+data network access. To set it up, follow the steps below:
+
+:::note
+The instructions below cover the steps for the MacOS-based systems. If you are running on a Linux-based system, you can find the 
+instructions [here](https://github.com/ceramicnetwork/rust-ceramic?tab=readme-ov-file#linux---debian-based-distributions).
+:::
+
+1. Install the component using [Homebrew](https://brew.sh/):
+
+```bash
+brew install ceramicnetwork/tap/ceramic-one
+```
+
+2. Start the `ceramic-one` using the following command:
+```bash
+ceramic-one daemon --network in-memory
+```
+
+:::note
+By default, the command above will spin off a node which connects to a `in-memory`. You can change this behaviour by providing a `--network` flag and specifying a network of your choice. For example:
+
+```ceramic-one daemon --network testnet-clay```
+:::
+
+---
+
+## Start the ComposeDB example app
+
 You can easily create a simple ComposeDB starter project by using our CLI and running the following command:
 
 <Tabs

--- a/docs/composedb/guides/composedb-server/server-configurations.mdx
+++ b/docs/composedb/guides/composedb-server/server-configurations.mdx
@@ -183,18 +183,6 @@ Only Postgres is currently supported for production usage.
 
 :::
 
-## History Sync
-By default, Ceramic nodes will only index documents they observe using pubsub messages. In order to index documents created before the node was deployed or configured to index some models, **History Sync** needs to be enabled on the Ceramic node, in the `daemon.config.json` file:
-
-```json
-{
-	...
-	"indexing": {
-    ...
-		"enable-historical-sync": true
-	}
-}
-```
 
 ## IPFS Process
 ### Available Configurations

--- a/docs/wheel/wheel-reference.mdx
+++ b/docs/wheel/wheel-reference.mdx
@@ -112,9 +112,9 @@ This section dives deeper into the Ceramic parameters you can configure when you
 
 An option to define if IFPS runs in the same compute process as Ceramic. You have two options to choose from:
 
-- Bundled - IPFS running in same compute process as Ceramic; recommended for early prototyping.
-- Remote - IPFS running in separate compute process; recommended for production and everything besides early prototyping.
-  This assumes that you have the IPFS process setup and can provide an IPFS Hostname.
+- Remote - IPFS running in separate compute process; recommended for all Ceramic versions that use `ceramic-one`. This configuration requires an IPFS Hostname. Default value is `http://localhost:5101`
+- Bundled - IPFS running in same compute process as Ceramic; used only with older Ceramic versions that use Kubo.
+
 
 ### State Store
 


### PR DESCRIPTION
Updating some of the outdate pieces in the guides:
- IPFS config in wheel
- ceramic-one config in example app
- HDS references removed